### PR TITLE
ci: fix incorrect sign off

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -122,7 +122,7 @@ jobs:
           pull-request-title-pattern: |
             chore${scope}: release${component} ${version}
 
-            Signed-off-by: github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>
+            Signed-off-by: Timo Glastra <timo@animo.id>
 
       # Initiate release process if release was created
       - name: Checkout aries-framework-javascript-ext


### PR DESCRIPTION
Signed-off-by: Timo Glastra <timo@animo.id>

Having issues with DCO sign-off. They use the same pattern in [AATH](https://github.com/hyperledger/aries-agent-test-harness/blob/main/.github/workflows/generate-summary-results.yml#L21-L26), but with personal email. Trying with my email now to see if that works... 

