### PR TITLE
ci: trigger on enabling auto merge

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -3,6 +3,7 @@ name: Continuous Integration
 on:
   pull_request:
     branches: [main]
+    types: [opened, synchronize, reopened, auto_merge_enabled]
   push:
     branches: [main]
 


### PR DESCRIPTION
CI is not triggered when a PR is opened by github actions,
but we need CI to pass before being able to merge a PR. This
will allow us to trigger CI on Github Actions created PRs
by enabling auto merge

Signed-off-by: Timo Glastra <timo@animo.id>