### PR TITLE
fix(push-notifications): add @id to messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,8 @@ All packages are placed in the [`packages/`](./packages) directory.
 
 If you would like to contribute to this repository, please read the [CONTRIBUTING](/CONTRIBUTING.md) guidelines. These documents will provide more information to get you started!
 
+For running tests, make sure to follow the network setup guides from the Aries Framework JavaScript [DEVREADME.md](https://github.com/hyperledger/aries-framework-javascript/blob/main/DEVREADME.md)
+
 The Aries Framework JavaScript call takes place every week at Thursday, 14:00 UTC via [Zoom](https://zoom.us/j/92215586249?pwd=Vm5ZTGV4T0cwVEl4blh3MjBzYjVYZz09). This meeting is for contributors to groom and plan the backlog, and discuss issues. Feel free to join!
 
 ## License

--- a/packages/push-notifications/src/messages/PushNotificationsDeviceInfoMessage.ts
+++ b/packages/push-notifications/src/messages/PushNotificationsDeviceInfoMessage.ts
@@ -6,16 +6,21 @@ import { Equals, IsString } from 'class-validator'
 
 import { DevicePlatform } from '../services'
 
+export interface PushNotificationsDeviceInfoOptions extends DeviceInfo {
+  id?: string
+}
+
 /**
  * Message to get the device information from another agent for push notifications
  *
  * @todo ADD RFC
  */
 export class PushNotificationsDeviceInfoMessage extends AgentMessage {
-  public constructor(options: DeviceInfo) {
+  public constructor(options: PushNotificationsDeviceInfoOptions) {
     super()
 
     if (options) {
+      this.id = options.id ?? this.generateId()
       this.deviceToken = options.deviceToken
       this.devicePlatform = options.devicePlatform
     }

--- a/packages/push-notifications/src/messages/PushNotificationsGetDeviceInfoMessage.ts
+++ b/packages/push-notifications/src/messages/PushNotificationsGetDeviceInfoMessage.ts
@@ -1,6 +1,10 @@
 import { AgentMessage } from '@aries-framework/core'
 import { Equals } from 'class-validator'
 
+interface PushNotificationsGetDeviceInfoOptions {
+  id?: string
+}
+
 /**
  * Message to get the device information from another agent for push notifications
  *
@@ -10,4 +14,12 @@ export class PushNotificationsGetDeviceInfoMessage extends AgentMessage {
   @Equals(PushNotificationsGetDeviceInfoMessage.type)
   public readonly type = PushNotificationsGetDeviceInfoMessage.type
   public static readonly type = 'https://didcomm.org/push-notifications-native/1.0/get-device-info'
+
+  public constructor(options: PushNotificationsGetDeviceInfoOptions) {
+    super()
+
+    if (options) {
+      this.id = options.id ?? this.generateId()
+    }
+  }
 }

--- a/packages/push-notifications/src/messages/PushNotificationsSetNativeDeviceInfoMessage.ts
+++ b/packages/push-notifications/src/messages/PushNotificationsSetNativeDeviceInfoMessage.ts
@@ -6,16 +6,21 @@ import { Equals, IsString } from 'class-validator'
 
 import { DevicePlatform } from '../services'
 
+export interface PushNotificationsSetNativeDeviceInfoOptions extends DeviceInfo {
+  id?: string
+}
+
 /**
  * Message to set the native device information at another agent for push notifications
  *
  * @todo ADD RFC
  */
 export class PushNotificationsSetNativeDeviceInfoMessage extends AgentMessage {
-  public constructor(options: DeviceInfo) {
+  public constructor(options: PushNotificationsSetNativeDeviceInfoOptions) {
     super()
 
     if (options) {
+      this.id = options.id ?? this.generateId()
       this.devicePlatform = options.devicePlatform
       this.deviceToken = options.deviceToken
     }

--- a/packages/push-notifications/src/services/PushNotificationsService.ts
+++ b/packages/push-notifications/src/services/PushNotificationsService.ts
@@ -19,6 +19,6 @@ export class PushNotificationsService {
   }
 
   public createGetDeviceInfo() {
-    return new PushNotificationsGetDeviceInfoMessage()
+    return new PushNotificationsGetDeviceInfoMessage({})
   }
 }

--- a/packages/push-notifications/tests/pushNotificationsService.test.ts
+++ b/packages/push-notifications/tests/pushNotificationsService.test.ts
@@ -1,8 +1,9 @@
 import type { Agent } from '@aries-framework/core'
 
-import { classToPlain } from 'class-transformer'
+import { JsonTransformer } from '@aries-framework/core'
+import { MessageValidator } from '@aries-framework/core/build/utils/MessageValidator'
 
-import 'reflect-metadata'
+import { PushNotificationsDeviceInfoMessage } from '../src'
 import { DevicePlatform, PushNotificationsService } from '../src/services'
 
 import { setupAgent } from './utils/agent'
@@ -33,10 +34,48 @@ describe('PushNotifications', () => {
         devicePlatform: DevicePlatform.Android,
       })
 
-      const jsonMessage = classToPlain(message)
+      const jsonMessage = JsonTransformer.toJSON(message)
+
+      await expect(MessageValidator.validate(message)).resolves.toBeUndefined()
 
       expect(jsonMessage).toEqual({
+        '@id': expect.any(String),
         '@type': 'https://didcomm.org/push-notifications-native/1.0/set-device-info',
+        device_token: '1234-1234-1234-1234',
+        device_platform: 'android',
+      })
+    })
+  })
+
+  describe('Create get device info Message', () => {
+    test('Should create a valid https://didcomm.org/push-notifications-native/1.0/get-device-info message ', async () => {
+      const message = pushNotificationsService.createGetDeviceInfo()
+
+      const jsonMessage = JsonTransformer.toJSON(message)
+
+      await expect(MessageValidator.validate(message)).resolves.toBeUndefined()
+
+      expect(jsonMessage).toEqual({
+        '@id': expect.any(String),
+        '@type': 'https://didcomm.org/push-notifications-native/1.0/get-device-info',
+      })
+    })
+  })
+
+  describe('PushNotificationsDeviceInfoMessage', () => {
+    test('Should create a valid https://didcomm.org/push-notifications-native/1.0/device-info message ', async () => {
+      const message = new PushNotificationsDeviceInfoMessage({
+        devicePlatform: DevicePlatform.Android,
+        deviceToken: '1234-1234-1234-1234',
+      })
+
+      const jsonMessage = JsonTransformer.toJSON(message)
+
+      await expect(MessageValidator.validate(message)).resolves.toBeUndefined()
+
+      expect(jsonMessage).toEqual({
+        '@id': expect.any(String),
+        '@type': 'https://didcomm.org/push-notifications-native/1.0/device-info',
         device_token: '1234-1234-1234-1234',
         device_platform: 'android',
       })

--- a/packages/rest/src/controllers/credentials/CredentialDefinitionController.ts
+++ b/packages/rest/src/controllers/credentials/CredentialDefinitionController.ts
@@ -34,7 +34,7 @@ export class CredentialDefinitionController {
     try {
       return await this.agent.ledger.getCredentialDefinition(credentialDefinitionId)
     } catch (error) {
-      if (error instanceof IndySdkError && isIndyError(error.cause, 'LedgerNotFound')) {
+      if (error instanceof LedgerNotFoundError) {
         throw new NotFoundError(
           `credential definition with credentialDefinitionId "${credentialDefinitionId}" not found.`
         )

--- a/packages/rest/src/controllers/credentials/SchemaController.ts
+++ b/packages/rest/src/controllers/credentials/SchemaController.ts
@@ -35,7 +35,7 @@ export class SchemaController {
     try {
       return await this.agent.ledger.getSchema(schemaId)
     } catch (error) {
-      if (error instanceof IndySdkError && isIndyError(error.cause, 'LedgerNotFound')) {
+      if (error instanceof LedgerNotFoundError) {
         throw new NotFoundError(`schema definition with schemaId "${schemaId}" not found.`)
       } else if (error instanceof LedgerError && error.cause instanceof IndySdkError) {
         if (isIndyError(error.cause.cause, 'LedgerInvalidTransaction')) {

--- a/packages/rest/tests/credentialDefinition.test.ts
+++ b/packages/rest/tests/credentialDefinition.test.ts
@@ -44,7 +44,7 @@ describe('CredentialDefinitionController', () => {
       expect(response.statusCode).toBe(400)
     })
 
-    test('should return 404 NotFound when schema not found', async () => {
+    test('should return 404 NotFound when credential definition not found', async () => {
       const response = await request(app).get(`/credential-definitions/WgWxqztrNooG92RXvxSTWv:3:CL:20:tag`)
       expect(response.statusCode).toBe(404)
     })

--- a/packages/rest/tests/utils/agent.ts
+++ b/packages/rest/tests/utils/agent.ts
@@ -3,8 +3,11 @@ import type { AutoAcceptCredential, InitConfig } from '@aries-framework/core'
 
 import { Agent, ConnectionInvitationMessage, HttpOutboundTransport } from '@aries-framework/core'
 import { agentDependencies, HttpInboundTransport } from '@aries-framework/node'
+import path from 'path'
 
-import { BCOVRIN_TEST_GENESIS } from './util'
+export const genesisPath = process.env.GENESIS_TXN_PATH
+  ? path.resolve(process.env.GENESIS_TXN_PATH)
+  : path.join(__dirname, '../../../../network/genesis/local-genesis.txn')
 
 export async function setupAgent({
   port,
@@ -33,8 +36,8 @@ export async function setupAgent({
     },
     indyLedgers: [
       {
-        id: 'BCovrin Test Genesis',
-        genesisTransactions: BCOVRIN_TEST_GENESIS,
+        id: 'LocalLedger',
+        genesisPath,
         isProduction: false,
       },
     ],


### PR DESCRIPTION
No `@id` was added to push notification messages which means AFJ would refuse to send the message due to validation errors.