### PR TITLE
fix(react-hooks): update providers on delete events

### DIFF
--- a/packages/react-hooks/package.json
+++ b/packages/react-hooks/package.json
@@ -25,13 +25,13 @@
     "test": "jest"
   },
   "devDependencies": {
-    "@aries-framework/core": "^0.1.0",
+    "@aries-framework/core": "0.2.0-alpha.112",
     "react": "^17.0.2",
     "rimraf": "~3.0.2",
     "typescript": "~4.4.2"
   },
   "peerDependencies": {
-    "@aries-framework/core": "^0.1.0",
+    "@aries-framework/core": "^0.2.0",
     "react": "^17.0.2"
   }
 }

--- a/packages/react-hooks/src/ConnectionProvider.tsx
+++ b/packages/react-hooks/src/ConnectionProvider.tsx
@@ -1,4 +1,4 @@
-import type { Agent, ConnectionState, ConnectionStateChangedEvent, ConnectionRecord } from '@aries-framework/core'
+import type { Agent, ConnectionStateChangedEvent, ConnectionRecord, DidExchangeState } from '@aries-framework/core'
 
 import { ConnectionEventTypes } from '@aries-framework/core'
 import * as React from 'react'
@@ -24,7 +24,7 @@ export const useConnectionById = (id: string): ConnectionRecord | undefined => {
   return connections.find((c: ConnectionRecord) => c.id === id)
 }
 
-export const useConnectionByState = (state: ConnectionState): ConnectionRecord[] => {
+export const useConnectionByState = (state: DidExchangeState): ConnectionRecord[] => {
   const { connections } = useConnections()
   const filteredConnections = useMemo(
     () => connections.filter((c: ConnectionRecord) => c.state === state),

--- a/packages/react-hooks/src/CredentialProvider.tsx
+++ b/packages/react-hooks/src/CredentialProvider.tsx
@@ -1,4 +1,9 @@
-import type { Agent, CredentialState, CredentialStateChangedEvent, CredentialRecord } from '@aries-framework/core'
+import type {
+  Agent,
+  CredentialState,
+  CredentialStateChangedEvent,
+  CredentialExchangeRecord,
+} from '@aries-framework/core'
 
 import { CredentialEventTypes } from '@aries-framework/core'
 import * as React from 'react'
@@ -6,7 +11,7 @@ import { createContext, useState, useEffect, useContext, useMemo } from 'react'
 
 interface CredentialContextInterface {
   loading: boolean
-  credentials: CredentialRecord[]
+  credentials: CredentialExchangeRecord[]
 }
 
 const CredentialContext = createContext<CredentialContextInterface | undefined>(undefined)
@@ -19,15 +24,15 @@ export const useCredentials = () => {
   return credentialContext
 }
 
-export const useCredentialById = (id: string): CredentialRecord | undefined => {
+export const useCredentialById = (id: string): CredentialExchangeRecord | undefined => {
   const { credentials } = useCredentials()
-  return credentials.find((c: CredentialRecord) => c.id === id)
+  return credentials.find((c: CredentialExchangeRecord) => c.id === id)
 }
 
-export const useCredentialByState = (state: CredentialState): CredentialRecord[] => {
+export const useCredentialByState = (state: CredentialState): CredentialExchangeRecord[] => {
   const { credentials } = useCredentials()
   const filteredCredentials = useMemo(
-    () => credentials.filter((c: CredentialRecord) => c.state === state),
+    () => credentials.filter((c: CredentialExchangeRecord) => c.state === state),
     [credentials, state]
   )
   return filteredCredentials

--- a/packages/react-hooks/src/CredentialProvider.tsx
+++ b/packages/react-hooks/src/CredentialProvider.tsx
@@ -1,11 +1,6 @@
-import type {
-  Agent,
-  CredentialState,
-  CredentialStateChangedEvent,
-  CredentialExchangeRecord,
-} from '@aries-framework/core'
+import type { Agent, CredentialState, CredentialStateChangedEvent, RecordDeletedEvent } from '@aries-framework/core'
 
-import { CredentialEventTypes } from '@aries-framework/core'
+import { CredentialEventTypes, CredentialExchangeRecord, RepositoryEventTypes } from '@aries-framework/core'
 import * as React from 'react'
 import { createContext, useState, useEffect, useContext, useMemo } from 'react'
 
@@ -61,7 +56,7 @@ const CredentialProvider: React.FC<Props> = ({ agent, children }) => {
 
   useEffect(() => {
     if (!credentialState.loading) {
-      const listener = async (event: CredentialStateChangedEvent) => {
+      const stateChangedListener = async (event: CredentialStateChangedEvent) => {
         const newCredentialsState = [...credentialState.credentials]
         const index = newCredentialsState.findIndex((credential) => credential.id === event.payload.credentialRecord.id)
         if (index > -1) {
@@ -76,10 +71,25 @@ const CredentialProvider: React.FC<Props> = ({ agent, children }) => {
         })
       }
 
-      agent?.events.on(CredentialEventTypes.CredentialStateChanged, listener)
+      const deletedListener = async (event: RecordDeletedEvent<CredentialExchangeRecord>) => {
+        if (event.payload.record.type !== CredentialExchangeRecord.type) {
+          return
+        }
+        const newCredentialsState = credentialState.credentials.filter(
+          (credential) => credential.id != event.payload.record.id
+        )
+        setCredentialState({
+          loading: credentialState.loading,
+          credentials: newCredentialsState,
+        })
+      }
+
+      agent?.events.on(CredentialEventTypes.CredentialStateChanged, stateChangedListener)
+      agent?.events.on(RepositoryEventTypes.RecordDeleted, deletedListener)
 
       return () => {
-        agent?.events.off(CredentialEventTypes.CredentialStateChanged, listener)
+        agent?.events.off(CredentialEventTypes.CredentialStateChanged, stateChangedListener)
+        agent?.events.off(RepositoryEventTypes.RecordDeleted, deletedListener)
       }
     }
   }, [credentialState, agent])

--- a/yarn.lock
+++ b/yarn.lock
@@ -30,6 +30,36 @@
     tsyringe "^4.5.0"
     uuid "^8.3.2"
 
+"@aries-framework/core@0.2.0-alpha.112":
+  version "0.2.0-alpha.112"
+  resolved "https://registry.yarnpkg.com/@aries-framework/core/-/core-0.2.0-alpha.112.tgz#c6aaa5063e0190e21def2c67b89d09d16d7cc865"
+  integrity sha512-4/JRAWBc1smIhwjynsjdEPu7LC0km+vZGHZTNFQ1aW/VHmyDAGAm7eUy/5v1ZLv2jZjN5AxU7fWVydISJzyOow==
+  dependencies:
+    "@multiformats/base-x" "^4.0.1"
+    "@stablelib/ed25519" "^1.0.2"
+    "@stablelib/sha256" "^1.0.1"
+    "@types/indy-sdk" "^1.16.16"
+    "@types/node-fetch" "^2.5.10"
+    "@types/ws" "^7.4.6"
+    abort-controller "^3.0.0"
+    bn.js "^5.2.0"
+    borc "^3.0.0"
+    buffer "^6.0.3"
+    class-transformer "0.5.1"
+    class-validator "0.13.1"
+    did-resolver "^3.1.3"
+    lru_map "^0.4.1"
+    luxon "^1.27.0"
+    make-error "^1.3.6"
+    object-inspect "^1.10.3"
+    query-string "^7.0.1"
+    reflect-metadata "^0.1.13"
+    rxjs "^7.2.0"
+    tsyringe "^4.5.0"
+    uuid "^8.3.2"
+    varint "^6.0.0"
+    web-did-resolver "^2.0.8"
+
 "@aries-framework/node@^0.1.0":
   version "0.1.0"
   resolved "https://registry.npmjs.org/@aries-framework/node/-/node-0.1.0.tgz"
@@ -655,6 +685,63 @@
   resolved "https://registry.npmjs.org/@sovpro/delimited-stream/-/delimited-stream-1.1.0.tgz"
   integrity sha512-kQpk267uxB19X3X2T1mvNMjyvIEonpNSHrMlK5ZaBU6aZxw7wPbpgKJOjHN3+/GPVpXgAV9soVT2oyHpLkLtyw==
 
+"@stablelib/binary@^1.0.1":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@stablelib/binary/-/binary-1.0.1.tgz#c5900b94368baf00f811da5bdb1610963dfddf7f"
+  integrity sha512-ClJWvmL6UBM/wjkvv/7m5VP3GMr9t0osr4yVgLZsLCOz4hGN9gIAFEqnJ0TsSMAN+n840nf2cHZnA5/KFqHC7Q==
+  dependencies:
+    "@stablelib/int" "^1.0.1"
+
+"@stablelib/ed25519@^1.0.2":
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/@stablelib/ed25519/-/ed25519-1.0.2.tgz#937a88a2f73a71d9bdc3ea276efe8954776ae0f4"
+  integrity sha512-FtnvUwvKbp6l1dNcg4CswMAVFVu/nzLK3oC7/PRtjYyHbWsIkD8j+5cjXHmwcCpdCpRCaTGACkEhhMQ1RcdSOQ==
+  dependencies:
+    "@stablelib/random" "^1.0.1"
+    "@stablelib/sha512" "^1.0.1"
+    "@stablelib/wipe" "^1.0.1"
+
+"@stablelib/hash@^1.0.1":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@stablelib/hash/-/hash-1.0.1.tgz#3c944403ff2239fad8ebb9015e33e98444058bc5"
+  integrity sha512-eTPJc/stDkdtOcrNMZ6mcMK1e6yBbqRBaNW55XA1jU8w/7QdnCF0CmMmOD1m7VSkBR44PWrMHU2l6r8YEQHMgg==
+
+"@stablelib/int@^1.0.1":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@stablelib/int/-/int-1.0.1.tgz#75928cc25d59d73d75ae361f02128588c15fd008"
+  integrity sha512-byr69X/sDtDiIjIV6m4roLVWnNNlRGzsvxw+agj8CIEazqWGOQp2dTYgQhtyVXV9wpO6WyXRQUzLV/JRNumT2w==
+
+"@stablelib/random@^1.0.1":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@stablelib/random/-/random-1.0.1.tgz#4357a00cb1249d484a9a71e6054bc7b8324a7009"
+  integrity sha512-zOh+JHX3XG9MSfIB0LZl/YwPP9w3o6WBiJkZvjPoKKu5LKFW4OLV71vMxWp9qG5T43NaWyn0QQTWgqCdO+yOBQ==
+  dependencies:
+    "@stablelib/binary" "^1.0.1"
+    "@stablelib/wipe" "^1.0.1"
+
+"@stablelib/sha256@^1.0.1":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@stablelib/sha256/-/sha256-1.0.1.tgz#77b6675b67f9b0ea081d2e31bda4866297a3ae4f"
+  integrity sha512-GIIH3e6KH+91FqGV42Kcj71Uefd/QEe7Dy42sBTeqppXV95ggCcxLTk39bEr+lZfJmp+ghsR07J++ORkRELsBQ==
+  dependencies:
+    "@stablelib/binary" "^1.0.1"
+    "@stablelib/hash" "^1.0.1"
+    "@stablelib/wipe" "^1.0.1"
+
+"@stablelib/sha512@^1.0.1":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@stablelib/sha512/-/sha512-1.0.1.tgz#6da700c901c2c0ceacbd3ae122a38ac57c72145f"
+  integrity sha512-13gl/iawHV9zvDKciLo1fQ8Bgn2Pvf7OV6amaRVKiq3pjQ3UmEpXxWiAfV8tYjUpeZroBxtyrwtdooQT/i3hzw==
+  dependencies:
+    "@stablelib/binary" "^1.0.1"
+    "@stablelib/hash" "^1.0.1"
+    "@stablelib/wipe" "^1.0.1"
+
+"@stablelib/wipe@^1.0.1":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@stablelib/wipe/-/wipe-1.0.1.tgz#d21401f1d59ade56a62e139462a97f104ed19a36"
+  integrity sha512-WfqfX/eXGiAd3RJe4VU2snh/ZPwtSjLG4ynQ/vYzvghTh7dHFcI1wl+nrkWG6lGhukOxOsUHfv8dUXr58D0ayg==
+
 "@szmarczak/http-timer@^4.0.5":
   version "4.0.6"
   resolved "https://registry.npmjs.org/@szmarczak/http-timer/-/http-timer-4.0.6.tgz"
@@ -801,6 +888,13 @@
   version "4.0.1"
   resolved "https://registry.npmjs.org/@types/http-cache-semantics/-/http-cache-semantics-4.0.1.tgz"
   integrity sha512-SZs7ekbP8CN0txVG2xVRH6EgKmEm31BOxA07vkFaETzZz1xh+cbt8BcI0slpymvwhx5dlFnQG2rTlPVQn+iRPQ==
+
+"@types/indy-sdk@^1.16.16":
+  version "1.16.17"
+  resolved "https://registry.yarnpkg.com/@types/indy-sdk/-/indy-sdk-1.16.17.tgz#cb090033951d078809f493036746804a1a594497"
+  integrity sha512-FI5urEpXiu/NHOoL1TciJDU38QusUBtPZv9FDMUOWPczl87fVb08CYHWYtAZoLnsKfi5zeGD+WEBpYC14aF9Uw==
+  dependencies:
+    buffer "^6.0.0"
 
 "@types/indy-sdk@^1.16.6":
   version "1.16.8"
@@ -983,7 +1077,7 @@
   resolved "https://registry.npmjs.org/@types/validator/-/validator-13.7.0.tgz"
   integrity sha512-+jBxVvXVuggZOrm04NR8z+5+bgoW4VZyLzUO+hmPPW1mVFL/HaitLAkizfv4yg9TbG8lkfHWVMQ11yDqrVVCzA==
 
-"@types/ws@^7.4.4":
+"@types/ws@^7.4.4", "@types/ws@^7.4.6":
   version "7.4.7"
   resolved "https://registry.npmjs.org/@types/ws/-/ws-7.4.7.tgz"
   integrity sha512-JQbbmxZTZehdc2iszGKs5oC3NFnjeay7mtAWrdt7qNtAVK0g19muApzAy4bm9byz79xa2ZnO/BOBC2R8RC5Lww==
@@ -1859,6 +1953,13 @@ create-require@^1.1.0:
   resolved "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz"
   integrity sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==
 
+cross-fetch@^3.1.5:
+  version "3.1.5"
+  resolved "https://registry.yarnpkg.com/cross-fetch/-/cross-fetch-3.1.5.tgz#e1389f44d9e7ba767907f7af8454787952ab534f"
+  integrity sha512-lvb1SBsI0Z7GDwmuid+mU3kWVBwTVUbe7S0H52yaaAdQOXq2YktTCZdlAcNKFzE6QtRz0snpw9bNiPeOIkkQvw==
+  dependencies:
+    node-fetch "2.6.7"
+
 cross-spawn@^7.0.2, cross-spawn@^7.0.3:
   version "7.0.3"
   resolved "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz"
@@ -2006,6 +2107,11 @@ dicer@0.2.5:
   dependencies:
     readable-stream "1.1.x"
     streamsearch "0.1.2"
+
+did-resolver@^3.1.3, did-resolver@^3.2.2:
+  version "3.2.2"
+  resolved "https://registry.yarnpkg.com/did-resolver/-/did-resolver-3.2.2.tgz#6f4e252a810f785d1b28a10265fad6dffee25158"
+  integrity sha512-Eeo2F524VM5N3W4GwglZrnul2y6TLTwMQP3In62JdG34NZoqihYyOZLk+5wUW8sSgvIYIcJM8Dlt3xsdKZZ3tg==
 
 diff-sequences@^27.4.0:
   version "27.4.0"
@@ -4249,7 +4355,7 @@ ngrok@^4.2.2:
   optionalDependencies:
     hpagent "^0.1.2"
 
-node-fetch@^2.6.1, node-fetch@^2.6.7:
+node-fetch@2.6.7, node-fetch@^2.6.1, node-fetch@^2.6.7:
   version "2.6.7"
   resolved "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz"
   integrity sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==
@@ -4959,6 +5065,13 @@ rxjs@^7.1.0:
   integrity sha512-7SQDi7xeTMCJpqViXh8gL/lebcwlp3d831F05+9B44A4B0WfsEwUQHR64gsH1kvJ+Ep/J9K2+n1hVl1CsGN23w==
   dependencies:
     tslib "~2.1.0"
+
+rxjs@^7.2.0:
+  version "7.5.5"
+  resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-7.5.5.tgz#2ebad89af0f560f460ad5cc4213219e1f7dd4e9f"
+  integrity sha512-sy+H0pQofO95VDmFLzyaw9xNJU4KTRSwQIGM6+iG3SypAtCiLDzpeG8sJrNCWn2Up9km+KhkvTdbkrdy+yzZdw==
+  dependencies:
+    tslib "^2.1.0"
 
 safe-buffer@5.1.2, safe-buffer@~5.1.0, safe-buffer@~5.1.1:
   version "5.1.2"
@@ -5689,6 +5802,11 @@ varint@^5.0.2:
   resolved "https://registry.npmjs.org/varint/-/varint-5.0.2.tgz"
   integrity sha512-lKxKYG6H03yCZUpAGOPOsMcGxd1RHCu1iKvEHYDPmTyq2HueGhD73ssNBqqQWfvYs04G9iUFRvmAVLW20Jw6ow==
 
+varint@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/varint/-/varint-6.0.0.tgz#9881eb0ce8feaea6512439d19ddf84bf551661d0"
+  integrity sha512-cXEIW6cfr15lFv563k4GuVuW/fiwjknytD37jIOLSdSWuOI6WnO/oKwmP2FQTU2l01LP8/M5TSAJpzUaGe3uWg==
+
 vary@^1, vary@^1.1.2, vary@~1.1.2:
   version "1.1.2"
   resolved "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz"
@@ -5714,6 +5832,14 @@ walker@^1.0.7:
   integrity sha512-ts/8E8l5b7kY0vlWLewOkDXMmPdLcVV4GmOQLyxuSswIJsweeFZtAsMF7k1Nszz+TYBQrlYRmzOnr398y1JemQ==
   dependencies:
     makeerror "1.0.12"
+
+web-did-resolver@^2.0.8:
+  version "2.0.18"
+  resolved "https://registry.yarnpkg.com/web-did-resolver/-/web-did-resolver-2.0.18.tgz#d31c737808c66e10bb9c4fea04a6f7ed19d96c4f"
+  integrity sha512-6jVQMbsNdzsRqnkEPKPfnfFY0IUJjt9LKy6h+tzjc9NhgI6MQWuvZf8ouGBw7W9qDvlAtHY+lrk6OEatjPJGZA==
+  dependencies:
+    cross-fetch "^3.1.5"
+    did-resolver "^3.2.2"
 
 webidl-conversions@^3.0.0:
   version "3.0.1"


### PR DESCRIPTION
There were no delete events in `core` package, so providers only listen to change events. Whenever a record is deleted, for example with: 
```
agent.credentials.deleteById(credentialId)
```
provider is not updated, and the `useCredentials` hook does not update returned credentials array.
This branch utilizes changes made in https://github.com/hyperledger/aries-framework-javascript/pull/716 and adds delete events listeners to fix that issue.

BREAKING CHANGE: `useConnectionByState` now needs a `DidExchangeState` state value instead of a `ConnectionState` state value.