### PR TITLE
feat(react-hooks): revocation notification events

### DIFF
--- a/packages/react-hooks/package.json
+++ b/packages/react-hooks/package.json
@@ -25,13 +25,13 @@
     "test": "jest"
   },
   "devDependencies": {
-    "@aries-framework/core": "^0.1.0",
+    "@aries-framework/core": "^0.2.0-alpha.56",
     "react": "^17.0.2",
     "rimraf": "~3.0.2",
     "typescript": "~4.4.2"
   },
   "peerDependencies": {
-    "@aries-framework/core": "^0.1.0",
+    "@aries-framework/core": "^0.2.0-alpha.56",
     "react": "^17.0.2"
   }
 }

--- a/packages/react-hooks/src/CredentialProvider.tsx
+++ b/packages/react-hooks/src/CredentialProvider.tsx
@@ -1,4 +1,4 @@
-import type { Agent, CredentialState, CredentialStateChangedEvent, CredentialRecord } from '@aries-framework/core'
+import type { Agent, CredentialState, CredentialStateChangedEvent, CredentialRecord, RevocationNotificationReceivedEvent } from '@aries-framework/core'
 
 import { CredentialEventTypes } from '@aries-framework/core'
 import * as React from 'react'
@@ -56,7 +56,7 @@ const CredentialProvider: React.FC<Props> = ({ agent, children }) => {
 
   useEffect(() => {
     if (!credentialState.loading) {
-      const listener = async (event: CredentialStateChangedEvent) => {
+      const listener = async (event: CredentialStateChangedEvent | RevocationNotificationReceivedEvent) => {
         const newCredentialsState = [...credentialState.credentials]
         const index = newCredentialsState.findIndex((credential) => credential.id === event.payload.credentialRecord.id)
         if (index > -1) {
@@ -72,9 +72,11 @@ const CredentialProvider: React.FC<Props> = ({ agent, children }) => {
       }
 
       agent?.events.on(CredentialEventTypes.CredentialStateChanged, listener)
+      agent?.events.on(CredentialEventTypes.RevocationNotificationReceived, listener)
 
       return () => {
         agent?.events.off(CredentialEventTypes.CredentialStateChanged, listener)
+        agent?.events.off(CredentialEventTypes.RevocationNotificationReceived, listener)
       }
     }
   }, [credentialState, agent])


### PR DESCRIPTION
Made it so Revocation Notification events will also trigger the CredentialProvider listener.