### PR TITLE
fix(react-hooks): update react peer dependency

### DIFF
--- a/packages/react-hooks/package.json
+++ b/packages/react-hooks/package.json
@@ -35,6 +35,6 @@
   },
   "peerDependencies": {
     "@aries-framework/core": "^0.2.0",
-    "react": "^18.0.0"
+    "react": ">=17.0.0 <19.0.0"
   }
 }

--- a/packages/react-hooks/package.json
+++ b/packages/react-hooks/package.json
@@ -29,12 +29,12 @@
   },
   "devDependencies": {
     "@aries-framework/core": "^0.2.0",
-    "react": "^17.0.2",
+    "react": "^18.0.0",
     "rimraf": "~3.0.2",
     "typescript": "~4.4.2"
   },
   "peerDependencies": {
     "@aries-framework/core": "^0.2.0",
-    "react": "^17.0.2"
+    "react": "^18.0.0"
   }
 }


### PR DESCRIPTION
This updates the React peer dependency to 18.0.0 as part of an effort to update Aries Bifold to newer versions of React Native. 

This would be considered a breaking change according to Semver due to the peer dependency change (via https://github.com/semver/semver/issues/502)