### PR TITLE
fix(react-hooks): filtering untyped connections

### DIFF
--- a/packages/react-hooks/src/ConnectionProvider.tsx
+++ b/packages/react-hooks/src/ConnectionProvider.tsx
@@ -45,7 +45,9 @@ export const useConnections = (options: UseConnectionsOptions = {}) => {
       if (options.connectionState && options.connectionState !== record.state) return false
 
       // Exclude records with certain connection types (if defined)
-      if (record.connectionTypes.length == 0) {return true}
+      if (record.connectionTypes.length == 0) {
+        return true
+      }
       const recordTypes = record.connectionTypes as Array<ConnectionType | string> | null
       if (options.excludedTypes && recordTypes) {
         return recordTypes.some((connectionType) => !options.excludedTypes?.includes(connectionType))

--- a/packages/react-hooks/src/ConnectionProvider.tsx
+++ b/packages/react-hooks/src/ConnectionProvider.tsx
@@ -45,6 +45,7 @@ export const useConnections = (options: UseConnectionsOptions = {}) => {
       if (options.connectionState && options.connectionState !== record.state) return false
 
       // Exclude records with certain connection types (if defined)
+      if (record.connectionTypes.length == 0) {return true}
       const recordTypes = record.connectionTypes as Array<ConnectionType | string> | null
       if (options.excludedTypes && recordTypes) {
         return recordTypes.some((connectionType) => !options.excludedTypes?.includes(connectionType))

--- a/packages/react-hooks/src/ConnectionProvider.tsx
+++ b/packages/react-hooks/src/ConnectionProvider.tsx
@@ -45,11 +45,8 @@ export const useConnections = (options: UseConnectionsOptions = {}) => {
       if (options.connectionState && options.connectionState !== record.state) return false
 
       // Exclude records with certain connection types (if defined)
-      if (record.connectionTypes.length == 0) {
-        return true
-      }
       const recordTypes = record.connectionTypes as Array<ConnectionType | string> | null
-      if (options.excludedTypes && recordTypes) {
+      if (options.excludedTypes && recordTypes && recordTypes.length !== 0) {
         return recordTypes.some((connectionType) => !options.excludedTypes?.includes(connectionType))
       }
       return true

--- a/packages/react-hooks/src/index.ts
+++ b/packages/react-hooks/src/index.ts
@@ -1,8 +1,14 @@
 import AgentProvider, { useAgent } from './AgentProvider'
 import { useBasicMessages, useBasicMessagesByConnectionId } from './BasicMessageProvider'
 import { useConnections, useConnectionById, useConnectionByState, useConnectionNotInState } from './ConnectionProvider'
-import { useCredentials, useCredentialById, useCredentialByState, useCredentialNotInState } from './CredentialProvider'
-import { useProofs, useProofById, useProofByState, useProofNotInState } from './ProofProvider'
+import {
+  useCredentials,
+  useCredentialById,
+  useCredentialByState,
+  useCredentialNotInState,
+  useCredentialsByConnectionId,
+} from './CredentialProvider'
+import { useProofs, useProofById, useProofByState, useProofNotInState, useProofsByConnectionId } from './ProofProvider'
 
 export {
   useAgent,
@@ -16,10 +22,12 @@ export {
   useCredentialById,
   useCredentialByState,
   useCredentialNotInState,
+  useCredentialsByConnectionId,
   useProofs,
   useProofById,
   useProofByState,
   useProofNotInState,
+  useProofsByConnectionId,
 }
 
 export default AgentProvider


### PR DESCRIPTION
Fixes an issue where the "excluded types" filter will filter connections with no type explicitly specified if it is used.