### PR TITLE
fix: loosen types on ble inbound and outbound transport and session

### DIFF
--- a/packages/transport-ble/src/transports/BleOutboundTransport.ts
+++ b/packages/transport-ble/src/transports/BleOutboundTransport.ts
@@ -1,21 +1,21 @@
-import type { Peripheral } from '@animo-id/react-native-ble-didcomm'
+import type { Ble } from '@animo-id/react-native-ble-didcomm'
 import type { Agent, Logger, OutboundPackage, OutboundTransport } from '@aries-framework/core'
 
 import { AriesFrameworkError } from '@aries-framework/core'
 
 export class BleOutboundTransport implements OutboundTransport {
   public supportedSchemes: string[] = ['ble']
-  private peripheral: Peripheral
+  private messenger: Ble
   private logger?: Logger
 
-  public constructor(peripheral: Peripheral) {
-    this.peripheral = peripheral
+  public constructor(messenger: Ble) {
+    this.messenger = messenger
   }
 
   public async start(agent: Agent): Promise<void> {
     this.logger = agent.config.logger
 
-    agent.config.logger.debug('Starting BLE outbound transport')
+    this.logger.debug('Starting BLE outbound transport')
   }
 
   public async sendMessage(outboundPackage: OutboundPackage): Promise<void> {
@@ -31,11 +31,11 @@ export class BleOutboundTransport implements OutboundTransport {
     const serializedMessage = JSON.stringify(payload)
 
     this.logger?.debug('Sending BLE outbound message')
-    await this.peripheral.sendMessage(serializedMessage)
+    await this.messenger.sendMessage(serializedMessage)
   }
 
   public async stop(): Promise<void> {
     this.logger?.debug('Stopping BLE outbound transport')
-    await this.peripheral.shutdown()
+    await this.messenger.shutdown()
   }
 }

--- a/packages/transport-ble/src/transports/BleTransportSession.ts
+++ b/packages/transport-ble/src/transports/BleTransportSession.ts
@@ -1,28 +1,29 @@
-import type { Central } from '@animo-id/react-native-ble-didcomm'
-import type { Agent, AgentContext, EncryptedMessage, TransportSession } from '@aries-framework/core'
+import type { Ble } from '@animo-id/react-native-ble-didcomm'
+import type { AgentContext, EncryptedMessage, TransportSession } from '@aries-framework/core'
 
 import { utils } from '@aries-framework/core'
 
 export class BleTransportSession implements TransportSession {
   public readonly type = 'ble'
   public id: string
-  private agent: Agent
-  private central: Central
 
-  public constructor(id: string, central: Central, agent: Agent) {
+  private agentContext: AgentContext
+  private messenger: Ble
+
+  public constructor(id: string, messenger: Ble, agentContext: AgentContext) {
     this.id = id ?? utils.uuid()
-    this.agent = agent
-    this.central = central
+    this.messenger = messenger
+    this.agentContext = agentContext
   }
 
   public async send(agentContext: AgentContext, encryptedMessage: EncryptedMessage): Promise<void> {
     const serializedMessage = JSON.stringify(encryptedMessage)
 
-    this.agent.config.logger.debug('Sending BLE inbound message via session')
-    await this.central.sendMessage(serializedMessage)
+    agentContext.config.logger.debug('Sending BLE inbound message via session')
+    await this.messenger.sendMessage(serializedMessage)
   }
 
   public async close(): Promise<void> {
-    this.agent.config.logger.debug('Stopping BLE inbound session')
+    this.agentContext.config.logger.debug('Stopping BLE inbound session')
   }
 }


### PR DESCRIPTION
- Types were unnecessarily strict and this loosens it a bit.
    - Now `Peripheral` and `Central` are both allowed for inbound and outbound as they both extend `Ble`
